### PR TITLE
Docker completion を追加

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -2,7 +2,9 @@
 source "$HOME/.zplug/init.zsh"
 zplug "zsh-users/zsh-completions", as:plugin
 zplug "chitoku-k/fzf-zsh-completions", as:plugin
+zplug "docker/cli", as:plugin, depth:1, use:"contrib/completion/zsh"
 zplug "romkatv/powerlevel10k", as:theme, depth:1, use:"powerlevel10k.zsh-theme"
+
 
 if ! zplug check --verbose; then
     printf "Install? [y/N]: "

--- a/.zshrc
+++ b/.zshrc
@@ -5,7 +5,6 @@ zplug "chitoku-k/fzf-zsh-completions", as:plugin
 zplug "docker/cli", as:plugin, depth:1, use:"contrib/completion/zsh"
 zplug "romkatv/powerlevel10k", as:theme, depth:1, use:"powerlevel10k.zsh-theme"
 
-
 if ! zplug check --verbose; then
     printf "Install? [y/N]: "
     if read -q; then


### PR DESCRIPTION
# Issue

#6 

## 詳細

fpath に追加が必要な completion などのコンテンツは `use:` をスクリプトじゃなくてディレクトリで指定すれば良い。